### PR TITLE
Fix loader if require is present but require('fs') is not

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -156,7 +156,7 @@ function file(filename) {
 }
 
 function fs() {
-  return typeof require === 'function' && require('fs');
+  return typeof require === 'function' && Object.keys(require('fs')).length > 0 && require('fs');
 }
 
 function startsWith(string, query) {


### PR DESCRIPTION
This bug currently prevents the vega-lite test gallery from loading.