### PR TITLE
v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ be useful for applications that load multiple data sets from the same domain.
 may safely omit a `'file://'` prefix.
 - *defaultProtocol*: The default protocol to use for protocol-relative *uri*
 values (e.g., `'//vega.github.io'`). Defaults to `'http'`.
-- *target*: The browser target attribute for hyperlinks. Only applies when sanitizing *uri* values for use as a hyperlink.
-- *headers*: An object of key-values indicating custom request headers, used
-only when loading via HTTP.
+- *target*: The browser target attribute for hyperlinks. Only applies when
+sanitizing *uri* values for use as a hyperlink.
+- *http*: HTTP request parameters passed to underlying calls to
+[fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API); see
+[RequestInit](https://fetch.spec.whatwg.org/#requestinit) for allowed properties.
 
 <a name="load" href="#load">#</a>
 loader.<b>load</b>(<i>uri</i>[, <i>options</i>])
@@ -82,13 +84,16 @@ names, values from the *options* argument for this method will be used.
 loader.<b>http</b>(<i>url</i>, <i>options</i>)
 [<>](https://github.com/vega/vega-loader/blob/master/src/loader.js "Source")
 
-Function used internally by [load](#load) for servicing HTTP requests. This
-method is over-writable for clients who wish to implement custom HTTP request
-handling. Uses [d3-request](https://github.com/d3/d3-request) by default.
+Function used internally by [load](#load) for servicing HTTP requests. Uses
+[fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) by default.
+Clients may overwrite this method to perform custom HTTP request handling.
 
-If provided, the *options* argument will be combined with any default options
-passed to the [loader](#loader) constructor. In the case of identical property
-names, values from the *options* argument for this method will be used.
+If provided, the *options* argument may include any valid fetch
+[RequestInit](https://fetch.spec.whatwg.org/#requestinit) properties. The
+provided *options* will be combined with any default options passed to the
+[loader](#loader) constructor under the *http* property. In the case of
+identical property names, values from the *options* argument for this
+method will be used.
 
 <a name="load_file" href="load_file">#</a>
 loader.<b>file</b>(<i>filename</i>)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "vega-loader",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Network request and file loading utilities.",
   "keywords": [
     "vega",
     "loader",
     "file",
     "http",
-    "xhr",
+    "fetch",
     "json",
     "csv",
     "tsv",
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "d3-dsv": "1",
-    "d3-request": "1",
     "d3-time-format": "2",
+    "node-fetch": "2",
     "topojson-client": "3",
     "vega-util": "1"
   },
@@ -50,6 +50,7 @@
   },
   "browser": {
     "buffer": false,
-    "fs": false
+    "fs": false,
+    "node-fetch": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,21 +30,21 @@
   },
   "scripts": {
     "build": "npm run test && uglifyjs build/vega-loader.js -c -m -o build/vega-loader.min.js",
-    "pretest": "rm -rf build && mkdir build&& rollup -f umd -g d3-dsv:d3,d3-request:d3,d3-time-format:d3,vega-util:vega,topojson-client:topojson -n vega -o build/vega-loader.js -- index.js",
+    "pretest": "rm -rf build && mkdir build&& rollup -f umd -g d3-dsv:d3,d3-time-format:d3,vega-util:vega,topojson-client:topojson -n vega -o build/vega-loader.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run build",
     "postpublish": "git push && git push --tags && zip -j build/vega-loader.zip -- LICENSE README.md build/vega-loader.js build/vega-loader.min.js"
   },
   "dependencies": {
-    "d3-dsv": "1",
-    "d3-time-format": "2",
-    "node-fetch": "2",
-    "topojson-client": "3",
-    "vega-util": "1"
+    "d3-dsv": "^1.0.8",
+    "d3-time-format": "^2.1.1",
+    "node-fetch": "^2.1.2",
+    "topojson-client": "^3.0.0",
+    "vega-util": "^1.7.0"
   },
   "devDependencies": {
     "eslint": "4",
-    "rollup": "0.43",
+    "rollup": "0.58.2",
     "tape": "4",
     "uglify-js": "3"
   },


### PR DESCRIPTION
Changes:
- Use [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to service requests, drop use of d3-request and XMLHttpRequest (XHR). Note that, while similar in many respects, fetch has a different default behavior than XHR. For example, fetch is more secure by default and does not share cookies or credentials unless configured to do so.
- Change loader _options_ format. Clients should use the _options.http_ object property to provide [fetch parameters](https://fetch.spec.whatwg.org/#requestinit). The _options.headers_ property is no longer supported, instead use _options.http.headers_.
- The loader `http` method now directly accepts an http parameter object rather than the top-level loader _options_. The loader's _options.http_ property is used as the base set of parameters, which may then be overridden by the _options_ argument to the `http` method.
- Update dependencies.